### PR TITLE
Allow scrolling

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -12,6 +12,7 @@
     right:20%;
     box-shadow: 0 0 9px lightgray;
     text-align: center;
+    overflow-y: scroll;
 }
 
 #main_input {


### PR DESCRIPTION
I tried the score checker on my mobile device and couldn't see the explanation for the results at the end of the page as scrolling wasn't allowed. 

Tested on: https://github-user-stats-glaukiol1.vercel.app/frontend/index.html

Fixed on: https://github-user-stats-website-florianbussmann.vercel.app/frontend/index.html